### PR TITLE
fix: properly wait for process to shutdown (#1)

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,7 @@
+# Documentation can be found at:
+# https://github.com/repository-settings/app/blob/master/docs/configuration.md
+_extends: jaredallard/jaredallard:settings.yml
+
+## <<Stencil::Block(custom)>>
+
+## <</Stencil::Block>>

--- a/cmd/downloader/downloader.go
+++ b/cmd/downloader/downloader.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -52,7 +53,7 @@ func entrypoint(cmd *cobra.Command, outputDir string) error {
 		return fmt.Errorf("output directory %q is not empty", outputDir)
 	}
 
-	return downloader.Download(version, sha256sum, outputDir)
+	return downloader.Download(cmd.Context(), version, sha256sum, outputDir)
 }
 
 // main runs sets up and runs Cobra.
@@ -62,7 +63,7 @@ func main() {
 	rootCmd.PersistentFlags().String("sha256sum", "",
 		"The SHA256 sum of the Factorio download, if set it will be used instead of fetching it.")
 
-	if err := rootCmd.Execute(); err != nil {
+	if err := rootCmd.ExecuteContext(context.Background()); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/wrapper/wrapper.go
+++ b/cmd/wrapper/wrapper.go
@@ -18,9 +18,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
 
 	charmlog "github.com/charmbracelet/log"
 
@@ -34,6 +36,9 @@ func entrypoint() error {
 	handler := charmlog.New(os.Stderr)
 	log := slog.New(handler)
 
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
 	cfg, err := config.Load()
 	if err != nil {
 		return err
@@ -43,12 +48,12 @@ func entrypoint() error {
 
 	// Ensure that we're using the requested version.
 	log.Info("Checking installed Factorio version")
-	if err := downloader.EnsureVersion(cfg, log); err != nil {
+	if err := downloader.EnsureVersion(ctx, cfg, log); err != nil {
 		return err
 	}
 
 	// Launch the Factorio server.
-	return launcher.Launch(log, cfg)
+	return launcher.Launch(ctx, log, cfg)
 }
 
 // main runs the entrypoint function. If it returns a non-nil error, it

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -18,6 +18,7 @@
 package downloader
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -27,7 +28,7 @@ import (
 // Download downloads the specified Factorio version to the output
 // directory. If version is "stable" or "experimental", it will download
 // the latest stable or experimental version, respectively.
-func Download(version, sha256sum, outputDir string) error {
+func Download(ctx context.Context, version, sha256sum, outputDir string) error {
 	// Ensure the output directory is empty.
 	if files, err := os.ReadDir(outputDir); err == nil && len(files) > 0 {
 		return fmt.Errorf("output directory %s is not empty", outputDir)
@@ -52,5 +53,5 @@ func Download(version, sha256sum, outputDir string) error {
 		}
 	}
 
-	return factorio.DownloadVersion(version, sha256sum, outputDir)
+	return factorio.DownloadVersion(ctx, version, sha256sum, outputDir)
 }

--- a/internal/downloader/installer.go
+++ b/internal/downloader/installer.go
@@ -16,6 +16,7 @@
 package downloader
 
 import (
+	"context"
 	_ "embed" // Embed the default Factorio config.
 	"fmt"
 	"log/slog"
@@ -27,7 +28,7 @@ import (
 )
 
 // EnsureVersion ensures that the Factorio server is installed and up-to-date.
-func EnsureVersion(cfg *config.Config, log *slog.Logger) error {
+func EnsureVersion(ctx context.Context, cfg *config.Config, log *slog.Logger) error {
 	st := state.Open(filepath.Join(cfg.InstallPath, "state.json"))
 
 	if st.Version == "" {
@@ -73,7 +74,7 @@ func EnsureVersion(cfg *config.Config, log *slog.Logger) error {
 	}
 
 	// The installed version is not the requested version, download it.
-	if err := Download(cfg.Version, "", cfg.InstallPath); err != nil {
+	if err := Download(ctx, cfg.Version, "", cfg.InstallPath); err != nil {
 		return err
 	}
 

--- a/internal/factorio/api_test.go
+++ b/internal/factorio/api_test.go
@@ -1,6 +1,7 @@
 package factorio_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,7 +32,7 @@ func TestCanGetLatestAndSHA256(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	t.Log("Downloading", rels.Stable, "to", tmpDir, "sha256:", stableSHA)
-	err = factorio.DownloadVersion(rels.Stable, stableSHA, tmpDir)
+	err = factorio.DownloadVersion(context.Background(), rels.Stable, stableSHA, tmpDir)
 	assert.NilError(t, err)
 
 	// Ensure it contains an expected file

--- a/internal/factorio/releases.go
+++ b/internal/factorio/releases.go
@@ -41,7 +41,13 @@ func DownloadVersion(ctx context.Context, version, sha256sum, destDir string) er
 		return err
 	}
 
-	resp, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://factorio.com/get-download/%s/headless/linux64", version), http.NoBody)
+	req, err := http.NewRequestWithContext(ctx,
+		"GET", fmt.Sprintf("https://factorio.com/get-download/%s/headless/linux64", version),
+		http.NoBody)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/internal/factorio/releases.go
+++ b/internal/factorio/releases.go
@@ -18,6 +18,7 @@ package factorio
 import (
 	"archive/tar"
 	"bufio"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -35,12 +36,12 @@ import (
 // DownloadVersion downloads a Factorio version to the specified
 // directory. The downloaded version is validated against the SHA256 sum
 // on the remote, and extracted to the specified directory.
-func DownloadVersion(version, sha256sum, destDir string) error {
+func DownloadVersion(ctx context.Context, version, sha256sum, destDir string) error {
 	if _, err := os.Stat(destDir); err != nil {
 		return err
 	}
 
-	resp, err := http.Get(fmt.Sprintf("https://factorio.com/get-download/%s/headless/linux64", version))
+	resp, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://factorio.com/get-download/%s/headless/linux64", version), http.NoBody)
 	if err != nil {
 		return err
 	}

--- a/internal/launcher/factocord.go
+++ b/internal/launcher/factocord.go
@@ -16,6 +16,7 @@
 package launcher
 
 import (
+	"context"
 	_ "embed" // Used w/ go:embed
 	"encoding/json"
 	"fmt"
@@ -81,7 +82,7 @@ func configureFactocord(cfg *config.Config, args []string) error {
 
 // runFactocord runs Factorio through the Factocord launcher to enable
 // Discord presence.
-func runFactocord(cfg *config.Config, args []string) error {
+func runFactocord(ctx context.Context, cfg *config.Config, args []string) error {
 	// Ensure the Factocord configuration is setup based on our
 	// configuration.
 	if err := configureFactocord(cfg, args); err != nil {
@@ -94,5 +95,5 @@ func runFactocord(cfg *config.Config, args []string) error {
 	}
 	newArgs = append(newArgs, args...)
 
-	return runVanilla(cfg, newArgs)
+	return runVanilla(ctx, cfg, newArgs)
 }

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -17,6 +17,7 @@
 package launcher
 
 import (
+	"context"
 	_ "embed" // Embed is used to embed default configuration files.
 	"fmt"
 	"io"
@@ -146,7 +147,7 @@ func installDefaultFiles(log *slog.Logger, cfg *config.Config) error {
 }
 
 // Launch starts a Factorio server based on the provided configuration.
-func Launch(log *slog.Logger, cfg *config.Config) error {
+func Launch(ctx context.Context, log *slog.Logger, cfg *config.Config) error {
 	if err := setupConfig(cfg); err != nil {
 		return fmt.Errorf("failed to setup config: %w", err)
 	}
@@ -177,8 +178,8 @@ func Launch(log *slog.Logger, cfg *config.Config) error {
 	}
 
 	if cfg.Factocord.Enabled {
-		return runFactocord(cfg, args)
+		return runFactocord(ctx, cfg, args)
 	}
 
-	return runVanilla(cfg, args)
+	return runVanilla(ctx, cfg, args)
 }


### PR DESCRIPTION
Passes context around and runs Factorio in it's own process group to
ensure that it's shutdown gracefully.

Resolves #1

Tested:

```bash
   1.491 Error ServerMultiplayerManager.cpp:751: Matching server connection failed: Error when creating server game: Missing token.
   1.526 Info ServerRouter.cpp:547: Own address is IP ADDR:({75.172.117.136:34197}) (confirmed by pingpong4)
   1.559 Info ServerRouter.cpp:547: Own address is IP ADDR:({75.172.117.136:34197}) (confirmed by pingpong2)
^C   2.760 Received SIGINT, shutting down
   2.761 Quitting: signal.
   2.762 Info MainLoop.cpp:446: Saving map as /data/saves/_autosave1.zip
   2.841 Info MainLoop.cpp:457: Saving progress: 0.250000%
   2.845 Info MainLoop.cpp:457: Saving progress: 100.000000%
   2.871 Info ServerMultiplayerManager.cpp:127: Disconnecting multiplayer connection.
   2.871 Info ServerMultiplayerManager.cpp:814: updateTick(0) changing state from(InGame) to(DisconnectingScheduled)
   2.910 Info ServerMultiplayerManager.cpp:814: updateTick(0) changing state from(DisconnectingScheduled) to(Disconnecting)
   2.944 Info ServerMultiplayerManager.cpp:814: updateTick(0) changing state from(Disconnecting) to(Disconnected)
   2.944 Info ServerMultiplayerManager.cpp:154: Quitting multiplayer connection.
   2.944 Info ServerMultiplayerManager.cpp:814: updateTick(0) changing state from(Disconnected) to(Closed)
   2.967 Info UDPSocket.cpp:233: Closing socket
   2.967 Info UDPSocket.cpp:263: Socket closed
   2.967 Info UDPSocket.cpp:233: Closing socket
   2.991 Info UDPSocket.cpp:233: Closing socket
   2.991 Info UDPSocket.cpp:263: Socket closed
   3.031 Goodbye
```
